### PR TITLE
Update the slow methods to match ActiveSupport’s current implementation

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -6,7 +6,7 @@ require 'fast_blank'
 class String
   # active support implementation
   def slow_blank?
-    self !~ /[^[:space:]]/
+    /\A[[:space:]]*\z/ === self
   end
 end
 
@@ -39,7 +39,7 @@ Benchmark.bmbm  do |x|
   end
 end
 
-                                            user     system      total        real
+#                                           user     system      total        real
 # Fast Blank 0    :                       0.050000   0.000000   0.050000 (  0.048928)
 # Fast Blank (Active Support)  0    :     0.050000   0.000000   0.050000 (  0.049967)
 # Slow Blank 0    :                       0.290000   0.000000   0.290000 (  0.295086)

--- a/spec/fast_blank_spec.rb
+++ b/spec/fast_blank_spec.rb
@@ -2,7 +2,7 @@ require 'fast_blank'
 
 class ::String
   def blank2?
-    self !~ /[^[:space:]]/
+    /\A[[:space:]]*\z/ === self
   end
 end
 
@@ -12,7 +12,6 @@ describe String do
     expect(" ".blank?).to eq(true)
     expect("\r\n".blank?).to eq(true)
     "\r\n\v\f\r\s\u0085".blank? == true
-
   end
 
   it "provides a parity with active support function" do


### PR DESCRIPTION
ActiveSupport's `String#blank?` has gone through some changes -- this updates the test and benchmark comparison methods to match [its current implementation](https://github.com/rails/rails/blob/722abe1722a8bcf1798fc7f7f9a8cf4dcfa28e88/activesupport/lib/active_support/core_ext/object/blank.rb#L101-L119).

Particularly notable is that it has been made more performant, via https://github.com/rails/rails/pull/12976 and https://github.com/rails/rails/pull/13519.  fast_blank still handily beats it, but it's less of a landslide.

Before:

```
Fast Blank (Active Support)  136    :   0.130000   0.000000   0.130000 (  0.130488)
Slow Blank 136    :                     1.060000   0.080000   1.140000 (  1.151207)
```

After:

```
Fast Blank (Active Support)  136    :   0.140000   0.000000   0.140000 (  0.135160)
Slow Blank 136    :                     0.560000   0.000000   0.560000 (  0.558274)
```