### PR TITLE
Bundling changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fast_blank (0.0.2)
+    fast_blank (1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -268,4 +268,4 @@ DEPENDENCIES
   rubysl (~> 2.0)
 
 BUNDLED WITH
-   1.10.3
+   1.10.6


### PR DESCRIPTION
@SamSaffron Looks like you missed this in the version bump.  This seems to be what's causing CI to fail in https://github.com/SamSaffron/fast_blank/pull/11, with:

```
Could not find fast_blank-0.0.2 in any of the sources
```

The `BUNDLED WITH` is just to avoid issues for anyone running between 1.10.3 and 1.10.6 -- it won't ever downgrade the BW value, but will avoid a dirty git status for those who have upgraded already.