### PR TITLE
Better benchmarking via benchmark-ips

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    benchmark-ips (2.3.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     coderay (1.1.0)
@@ -260,6 +261,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  benchmark-ips
   fast_blank!
   guard-rspec
   rake

--- a/README.md
+++ b/README.md
@@ -10,89 +10,89 @@
 
 ### How fast is "Fast"?
 
-About 3.5–8x faster than Active Support on my machine (your mileage my vary):
+About 6–20x faster than Active Support on my machine (your mileage my vary):
 
 ```
 $ bundle exec ./benchmark
 
 ================== Test String Length: 0 ==================
 Calculating -------------------------------------
-          Fast Blank   112.678k i/100ms
-  Fast ActiveSupport   120.580k i/100ms
-          Slow Blank    49.168k i/100ms
+          Fast Blank   130.949k i/100ms
+  Fast ActiveSupport   129.356k i/100ms
+          Slow Blank    56.008k i/100ms
 -------------------------------------------------
-          Fast Blank      6.695M (±15.2%) i/s -     32.677M
-  Fast ActiveSupport      6.760M (±15.1%) i/s -     33.039M
-          Slow Blank    856.495k (±28.3%) i/s -      3.884M
+          Fast Blank     21.520M (±10.4%) i/s -    105.938M
+  Fast ActiveSupport     21.347M (± 9.5%) i/s -    105.425M
+          Slow Blank      1.106M (±30.1%) i/s -      4.929M
 
 Comparison:
-  Fast ActiveSupport:  6760238.6 i/s
-          Fast Blank:  6694767.8 i/s - 1.01x slower
-          Slow Blank:   856494.6 i/s - 7.89x slower
+          Fast Blank: 21520211.2 i/s
+  Fast ActiveSupport: 21347192.0 i/s - 1.01x slower
+          Slow Blank:  1105743.4 i/s - 19.46x slower
 
 
 ================== Test String Length: 6 ==================
 Calculating -------------------------------------
-          Fast Blank   108.887k i/100ms
-  Fast ActiveSupport   108.098k i/100ms
-          Slow Blank    45.443k i/100ms
+          Fast Blank   121.226k i/100ms
+  Fast ActiveSupport   121.165k i/100ms
+          Slow Blank    50.455k i/100ms
 -------------------------------------------------
-          Fast Blank      4.305M (±19.8%) i/s -     20.253M
-  Fast ActiveSupport      5.225M (±12.0%) i/s -     25.727M
-          Slow Blank    827.722k (±26.3%) i/s -      3.817M
+          Fast Blank      9.595M (± 9.8%) i/s -     47.399M
+  Fast ActiveSupport     10.583M (± 8.5%) i/s -     52.464M
+          Slow Blank    964.469k (±27.6%) i/s -      4.390M
 
 Comparison:
-  Fast ActiveSupport:  5225360.3 i/s
-          Fast Blank:  4304868.6 i/s - 1.21x slower
-          Slow Blank:   827721.6 i/s - 6.31x slower
+  Fast ActiveSupport: 10583227.9 i/s
+          Fast Blank:  9594957.8 i/s - 1.10x slower
+          Slow Blank:   964468.9 i/s - 10.97x slower
 
 
 ================== Test String Length: 14 ==================
 Calculating -------------------------------------
-          Fast Blank   127.247k i/100ms
-  Fast ActiveSupport   127.443k i/100ms
-          Slow Blank    78.641k i/100ms
+          Fast Blank   129.496k i/100ms
+  Fast ActiveSupport   129.604k i/100ms
+          Slow Blank    83.756k i/100ms
 -------------------------------------------------
-          Fast Blank      6.704M (±11.4%) i/s -     33.084M
-  Fast ActiveSupport      6.811M (±10.9%) i/s -     33.645M
-          Slow Blank      1.789M (± 8.4%) i/s -      8.965M
+          Fast Blank     17.970M (± 9.3%) i/s -     88.834M
+  Fast ActiveSupport     18.181M (± 9.3%) i/s -     89.816M
+          Slow Blank      2.428M (± 6.8%) i/s -     12.145M
 
 Comparison:
-  Fast ActiveSupport:  6811231.1 i/s
-          Fast Blank:  6704016.0 i/s - 1.02x slower
-          Slow Blank:  1788751.1 i/s - 3.81x slower
+  Fast ActiveSupport: 18180635.5 i/s
+          Fast Blank: 17969809.8 i/s - 1.01x slower
+          Slow Blank:  2428259.9 i/s - 7.49x slower
 
 
 ================== Test String Length: 24 ==================
 Calculating -------------------------------------
-          Fast Blank   121.925k i/100ms
-  Fast ActiveSupport   121.461k i/100ms
-          Slow Blank    73.723k i/100ms
+          Fast Blank   122.337k i/100ms
+  Fast ActiveSupport   126.468k i/100ms
+          Slow Blank    76.495k i/100ms
 -------------------------------------------------
-          Fast Blank      5.399M (±12.5%) i/s -     26.580M
-  Fast ActiveSupport      5.584M (±11.7%) i/s -     27.572M
-          Slow Blank      1.563M (± 8.4%) i/s -      7.815M
+          Fast Blank     11.960M (± 9.4%) i/s -     59.211M
+  Fast ActiveSupport     12.421M (± 9.6%) i/s -     61.337M
+          Slow Blank      2.104M (± 8.0%) i/s -     10.480M
 
 Comparison:
-  Fast ActiveSupport:  5584121.3 i/s
-          Fast Blank:  5398896.6 i/s - 1.03x slower
-          Slow Blank:  1562511.2 i/s - 3.57x slower
+  Fast ActiveSupport: 12421448.7 i/s
+          Fast Blank: 11959811.7 i/s - 1.04x slower
+          Slow Blank:  2103905.1 i/s - 5.90x slower
 
 
 ================== Test String Length: 136 ==================
 Calculating -------------------------------------
-          Fast Blank   120.336k i/100ms
-  Fast ActiveSupport   124.404k i/100ms
-          Slow Blank    75.506k i/100ms
+          Fast Blank   123.617k i/100ms
+  Fast ActiveSupport   123.682k i/100ms
+          Slow Blank    76.362k i/100ms
 -------------------------------------------------
-          Fast Blank      5.536M (±11.2%) i/s -     27.316M
-  Fast ActiveSupport      5.622M (±12.0%) i/s -     27.742M
-          Slow Blank      1.582M (± 7.6%) i/s -      7.928M
+          Fast Blank     11.952M (±11.5%) i/s -     58.594M
+  Fast ActiveSupport     12.520M (± 9.0%) i/s -     61.965M
+          Slow Blank      2.112M (± 6.9%) i/s -     10.538M
 
 Comparison:
-  Fast ActiveSupport:  5622323.3 i/s
-          Fast Blank:  5535617.1 i/s - 1.02x slower
-          Slow Blank:  1582003.7 i/s - 3.55x slower
+  Fast ActiveSupport: 12520143.0 i/s
+          Fast Blank: 11952169.1 i/s - 1.05x slower
+          Slow Blank:  2112055.6 i/s - 5.93x slower
 ```
 
 Additionally, this gem allocates no strings during the test, making it less of a GC burden.

--- a/README.md
+++ b/README.md
@@ -12,25 +12,87 @@
 
 About 3.5–8x faster than Active Support on my machine (your mileage my vary):
 
-    $ ./benchmark
-
 ```
-                                            user     system      total        real
-Fast Blank 0    :                       0.080000   0.000000   0.080000 (  0.084032)
-Fast Blank (Active Support)  0    :     0.080000   0.000000   0.080000 (  0.083599)
-Slow Blank 0    :                       0.930000   0.050000   0.980000 (  0.986029)
-Fast Blank 6    :                       0.150000   0.000000   0.150000 (  0.156408)
-Fast Blank (Active Support)  6    :     0.130000   0.000000   0.130000 (  0.123618)
-Slow Blank 6    :                       1.080000   0.050000   1.130000 (  1.133616)
-Fast Blank 14    :                      0.090000   0.000000   0.090000 (  0.090577)
-Fast Blank (Active Support)  14    :    0.090000   0.000000   0.090000 (  0.096469)
-Slow Blank 14    :                      0.500000   0.000000   0.500000 (  0.501756)
-Fast Blank 24    :                      0.130000   0.000000   0.130000 (  0.124822)
-Fast Blank (Active Support)  24    :    0.110000   0.000000   0.110000 (  0.116654)
-Slow Blank 24    :                      0.560000   0.000000   0.560000 (  0.556493)
-Fast Blank 136    :                     0.130000   0.000000   0.130000 (  0.129399)
-Fast Blank (Active Support)  136    :   0.120000   0.000000   0.120000 (  0.120694)
-Slow Blank 136    :                     0.540000   0.000000   0.540000 (  0.545197)
+$ bundle exec ./benchmark
+
+================== Test String Length: 0 ==================
+Calculating -------------------------------------
+          Fast Blank   112.678k i/100ms
+  Fast ActiveSupport   120.580k i/100ms
+          Slow Blank    49.168k i/100ms
+-------------------------------------------------
+          Fast Blank      6.695M (±15.2%) i/s -     32.677M
+  Fast ActiveSupport      6.760M (±15.1%) i/s -     33.039M
+          Slow Blank    856.495k (±28.3%) i/s -      3.884M
+
+Comparison:
+  Fast ActiveSupport:  6760238.6 i/s
+          Fast Blank:  6694767.8 i/s - 1.01x slower
+          Slow Blank:   856494.6 i/s - 7.89x slower
+
+
+================== Test String Length: 6 ==================
+Calculating -------------------------------------
+          Fast Blank   108.887k i/100ms
+  Fast ActiveSupport   108.098k i/100ms
+          Slow Blank    45.443k i/100ms
+-------------------------------------------------
+          Fast Blank      4.305M (±19.8%) i/s -     20.253M
+  Fast ActiveSupport      5.225M (±12.0%) i/s -     25.727M
+          Slow Blank    827.722k (±26.3%) i/s -      3.817M
+
+Comparison:
+  Fast ActiveSupport:  5225360.3 i/s
+          Fast Blank:  4304868.6 i/s - 1.21x slower
+          Slow Blank:   827721.6 i/s - 6.31x slower
+
+
+================== Test String Length: 14 ==================
+Calculating -------------------------------------
+          Fast Blank   127.247k i/100ms
+  Fast ActiveSupport   127.443k i/100ms
+          Slow Blank    78.641k i/100ms
+-------------------------------------------------
+          Fast Blank      6.704M (±11.4%) i/s -     33.084M
+  Fast ActiveSupport      6.811M (±10.9%) i/s -     33.645M
+          Slow Blank      1.789M (± 8.4%) i/s -      8.965M
+
+Comparison:
+  Fast ActiveSupport:  6811231.1 i/s
+          Fast Blank:  6704016.0 i/s - 1.02x slower
+          Slow Blank:  1788751.1 i/s - 3.81x slower
+
+
+================== Test String Length: 24 ==================
+Calculating -------------------------------------
+          Fast Blank   121.925k i/100ms
+  Fast ActiveSupport   121.461k i/100ms
+          Slow Blank    73.723k i/100ms
+-------------------------------------------------
+          Fast Blank      5.399M (±12.5%) i/s -     26.580M
+  Fast ActiveSupport      5.584M (±11.7%) i/s -     27.572M
+          Slow Blank      1.563M (± 8.4%) i/s -      7.815M
+
+Comparison:
+  Fast ActiveSupport:  5584121.3 i/s
+          Fast Blank:  5398896.6 i/s - 1.03x slower
+          Slow Blank:  1562511.2 i/s - 3.57x slower
+
+
+================== Test String Length: 136 ==================
+Calculating -------------------------------------
+          Fast Blank   120.336k i/100ms
+  Fast ActiveSupport   124.404k i/100ms
+          Slow Blank    75.506k i/100ms
+-------------------------------------------------
+          Fast Blank      5.536M (±11.2%) i/s -     27.316M
+  Fast ActiveSupport      5.622M (±12.0%) i/s -     27.742M
+          Slow Blank      1.582M (± 7.6%) i/s -      7.928M
+
+Comparison:
+  Fast ActiveSupport:  5622323.3 i/s
+          Fast Blank:  5535617.1 i/s - 1.02x slower
+          Slow Blank:  1582003.7 i/s - 3.55x slower
 ```
 
 Additionally, this gem allocates no strings during the test, making it less of a GC burden.

--- a/benchmark
+++ b/benchmark
@@ -29,9 +29,29 @@ end
 test_strings.each do |s|
   puts "\n================== Test String Length: #{s.length} =================="
   Benchmark.ips do |x|
-    x.report("Fast Blank") { s.blank? }
-    x.report("Fast ActiveSupport") { s.blank_as? }
-    x.report("Slow Blank") { s.slow_blank? }
+    x.report("Fast Blank") do |times|
+      i = 0
+      while i < times
+        s.blank?
+        i += 1
+      end
+    end
+
+    x.report("Fast ActiveSupport") do |times|
+      i = 0
+      while i < times
+        s.blank_as?
+        i += 1
+      end
+    end
+
+    x.report("Slow Blank") do |times|
+      i = 0
+      while i < times
+        s.slow_blank?
+        i += 1
+      end
+    end
 
     x.compare!
   end
@@ -41,80 +61,80 @@ end
 #
 # ================== Test String Length: 0 ==================
 # Calculating -------------------------------------
-#           Fast Blank   112.678k i/100ms
-#   Fast ActiveSupport   120.580k i/100ms
-#           Slow Blank    49.168k i/100ms
+#           Fast Blank   130.949k i/100ms
+#   Fast ActiveSupport   129.356k i/100ms
+#           Slow Blank    56.008k i/100ms
 # -------------------------------------------------
-#           Fast Blank      6.695M (±15.2%) i/s -     32.677M
-#   Fast ActiveSupport      6.760M (±15.1%) i/s -     33.039M
-#           Slow Blank    856.495k (±28.3%) i/s -      3.884M
+#           Fast Blank     21.520M (±10.4%) i/s -    105.938M
+#   Fast ActiveSupport     21.347M (± 9.5%) i/s -    105.425M
+#           Slow Blank      1.106M (±30.1%) i/s -      4.929M
 #
 # Comparison:
-#   Fast ActiveSupport:  6760238.6 i/s
-#           Fast Blank:  6694767.8 i/s - 1.01x slower
-#           Slow Blank:   856494.6 i/s - 7.89x slower
+#           Fast Blank: 21520211.2 i/s
+#   Fast ActiveSupport: 21347192.0 i/s - 1.01x slower
+#           Slow Blank:  1105743.4 i/s - 19.46x slower
 #
 #
 # ================== Test String Length: 6 ==================
 # Calculating -------------------------------------
-#           Fast Blank   108.887k i/100ms
-#   Fast ActiveSupport   108.098k i/100ms
-#           Slow Blank    45.443k i/100ms
+#           Fast Blank   121.226k i/100ms
+#   Fast ActiveSupport   121.165k i/100ms
+#           Slow Blank    50.455k i/100ms
 # -------------------------------------------------
-#           Fast Blank      4.305M (±19.8%) i/s -     20.253M
-#   Fast ActiveSupport      5.225M (±12.0%) i/s -     25.727M
-#           Slow Blank    827.722k (±26.3%) i/s -      3.817M
+#           Fast Blank      9.595M (± 9.8%) i/s -     47.399M
+#   Fast ActiveSupport     10.583M (± 8.5%) i/s -     52.464M
+#           Slow Blank    964.469k (±27.6%) i/s -      4.390M
 #
 # Comparison:
-#   Fast ActiveSupport:  5225360.3 i/s
-#           Fast Blank:  4304868.6 i/s - 1.21x slower
-#           Slow Blank:   827721.6 i/s - 6.31x slower
+#   Fast ActiveSupport: 10583227.9 i/s
+#           Fast Blank:  9594957.8 i/s - 1.10x slower
+#           Slow Blank:   964468.9 i/s - 10.97x slower
 #
 #
 # ================== Test String Length: 14 ==================
 # Calculating -------------------------------------
-#           Fast Blank   127.247k i/100ms
-#   Fast ActiveSupport   127.443k i/100ms
-#           Slow Blank    78.641k i/100ms
+#           Fast Blank   129.496k i/100ms
+#   Fast ActiveSupport   129.604k i/100ms
+#           Slow Blank    83.756k i/100ms
 # -------------------------------------------------
-#           Fast Blank      6.704M (±11.4%) i/s -     33.084M
-#   Fast ActiveSupport      6.811M (±10.9%) i/s -     33.645M
-#           Slow Blank      1.789M (± 8.4%) i/s -      8.965M
+#           Fast Blank     17.970M (± 9.3%) i/s -     88.834M
+#   Fast ActiveSupport     18.181M (± 9.3%) i/s -     89.816M
+#           Slow Blank      2.428M (± 6.8%) i/s -     12.145M
 #
 # Comparison:
-#   Fast ActiveSupport:  6811231.1 i/s
-#           Fast Blank:  6704016.0 i/s - 1.02x slower
-#           Slow Blank:  1788751.1 i/s - 3.81x slower
+#   Fast ActiveSupport: 18180635.5 i/s
+#           Fast Blank: 17969809.8 i/s - 1.01x slower
+#           Slow Blank:  2428259.9 i/s - 7.49x slower
 #
 #
 # ================== Test String Length: 24 ==================
 # Calculating -------------------------------------
-#           Fast Blank   121.925k i/100ms
-#   Fast ActiveSupport   121.461k i/100ms
-#           Slow Blank    73.723k i/100ms
+#           Fast Blank   122.337k i/100ms
+#   Fast ActiveSupport   126.468k i/100ms
+#           Slow Blank    76.495k i/100ms
 # -------------------------------------------------
-#           Fast Blank      5.399M (±12.5%) i/s -     26.580M
-#   Fast ActiveSupport      5.584M (±11.7%) i/s -     27.572M
-#           Slow Blank      1.563M (± 8.4%) i/s -      7.815M
+#           Fast Blank     11.960M (± 9.4%) i/s -     59.211M
+#   Fast ActiveSupport     12.421M (± 9.6%) i/s -     61.337M
+#           Slow Blank      2.104M (± 8.0%) i/s -     10.480M
 #
 # Comparison:
-#   Fast ActiveSupport:  5584121.3 i/s
-#           Fast Blank:  5398896.6 i/s - 1.03x slower
-#           Slow Blank:  1562511.2 i/s - 3.57x slower
+#   Fast ActiveSupport: 12421448.7 i/s
+#           Fast Blank: 11959811.7 i/s - 1.04x slower
+#           Slow Blank:  2103905.1 i/s - 5.90x slower
 #
 #
 # ================== Test String Length: 136 ==================
 # Calculating -------------------------------------
-#           Fast Blank   120.336k i/100ms
-#   Fast ActiveSupport   124.404k i/100ms
-#           Slow Blank    75.506k i/100ms
+#           Fast Blank   123.617k i/100ms
+#   Fast ActiveSupport   123.682k i/100ms
+#           Slow Blank    76.362k i/100ms
 # -------------------------------------------------
-#           Fast Blank      5.536M (±11.2%) i/s -     27.316M
-#   Fast ActiveSupport      5.622M (±12.0%) i/s -     27.742M
-#           Slow Blank      1.582M (± 7.6%) i/s -      7.928M
+#           Fast Blank     11.952M (±11.5%) i/s -     58.594M
+#   Fast ActiveSupport     12.520M (± 9.0%) i/s -     61.965M
+#           Slow Blank      2.112M (± 6.9%) i/s -     10.538M
 #
 # Comparison:
-#   Fast ActiveSupport:  5622323.3 i/s
-#           Fast Blank:  5535617.1 i/s - 1.02x slower
-#           Slow Blank:  1582003.7 i/s - 3.55x slower
+#   Fast ActiveSupport: 12520143.0 i/s
+#           Fast Blank: 11952169.1 i/s - 1.05x slower
+#           Slow Blank:  2112055.6 i/s - 5.93x slower
 #

--- a/benchmark
+++ b/benchmark
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 $: << File.dirname(__FILE__)+'/lib'
-require 'benchmark'
+require 'benchmark/ips'
 require 'fast_blank'
 
 class String
@@ -10,11 +10,7 @@ class String
   end
 end
 
-
-n = 1000000
-
-
-strings = [
+test_strings = [
   "",
   "\r\n\r\n  ",
   "this is a test",
@@ -26,32 +22,99 @@ strings = [
       this is a longer test"
 ]
 
-strings.each do |s|
+test_strings.each do |s|
   raise "failed on #{s.inspect}" if s.blank? != s.slow_blank?
 end
 
-Benchmark.bmbm  do |x|
-  strings.each do |s|
-    x.report("Fast Blank #{s.length}    :") do  n.times { s.blank? }  end
-    x.report("Fast Blank (Active Support)  #{s.length}    :") do  n.times { s.blank_as? }  end
-    x.report("Slow Blank #{s.length}    :") do  n.times { s.slow_blank? }  end
-    #x.report("Empty #{s.length}    :") do  n.times { s.empty? }  end
+test_strings.each do |s|
+  puts "\n================== Test String Length: #{s.length} =================="
+  Benchmark.ips do |x|
+    x.report("Fast Blank") { s.blank? }
+    x.report("Fast ActiveSupport") { s.blank_as? }
+    x.report("Slow Blank") { s.slow_blank? }
+
+    x.compare!
   end
 end
 
-#                                             user     system      total        real
-# Fast Blank 0    :                       0.080000   0.000000   0.080000 (  0.084032)
-# Fast Blank (Active Support)  0    :     0.080000   0.000000   0.080000 (  0.083599)
-# Slow Blank 0    :                       0.930000   0.050000   0.980000 (  0.986029)
-# Fast Blank 6    :                       0.150000   0.000000   0.150000 (  0.156408)
-# Fast Blank (Active Support)  6    :     0.130000   0.000000   0.130000 (  0.123618)
-# Slow Blank 6    :                       1.080000   0.050000   1.130000 (  1.133616)
-# Fast Blank 14    :                      0.090000   0.000000   0.090000 (  0.090577)
-# Fast Blank (Active Support)  14    :    0.090000   0.000000   0.090000 (  0.096469)
-# Slow Blank 14    :                      0.500000   0.000000   0.500000 (  0.501756)
-# Fast Blank 24    :                      0.130000   0.000000   0.130000 (  0.124822)
-# Fast Blank (Active Support)  24    :    0.110000   0.000000   0.110000 (  0.116654)
-# Slow Blank 24    :                      0.560000   0.000000   0.560000 (  0.556493)
-# Fast Blank 136    :                     0.130000   0.000000   0.130000 (  0.129399)
-# Fast Blank (Active Support)  136    :   0.120000   0.000000   0.120000 (  0.120694)
-# Slow Blank 136    :                     0.540000   0.000000   0.540000 (  0.545197)
+
+#
+# ================== Test String Length: 0 ==================
+# Calculating -------------------------------------
+#           Fast Blank   112.678k i/100ms
+#   Fast ActiveSupport   120.580k i/100ms
+#           Slow Blank    49.168k i/100ms
+# -------------------------------------------------
+#           Fast Blank      6.695M (±15.2%) i/s -     32.677M
+#   Fast ActiveSupport      6.760M (±15.1%) i/s -     33.039M
+#           Slow Blank    856.495k (±28.3%) i/s -      3.884M
+#
+# Comparison:
+#   Fast ActiveSupport:  6760238.6 i/s
+#           Fast Blank:  6694767.8 i/s - 1.01x slower
+#           Slow Blank:   856494.6 i/s - 7.89x slower
+#
+#
+# ================== Test String Length: 6 ==================
+# Calculating -------------------------------------
+#           Fast Blank   108.887k i/100ms
+#   Fast ActiveSupport   108.098k i/100ms
+#           Slow Blank    45.443k i/100ms
+# -------------------------------------------------
+#           Fast Blank      4.305M (±19.8%) i/s -     20.253M
+#   Fast ActiveSupport      5.225M (±12.0%) i/s -     25.727M
+#           Slow Blank    827.722k (±26.3%) i/s -      3.817M
+#
+# Comparison:
+#   Fast ActiveSupport:  5225360.3 i/s
+#           Fast Blank:  4304868.6 i/s - 1.21x slower
+#           Slow Blank:   827721.6 i/s - 6.31x slower
+#
+#
+# ================== Test String Length: 14 ==================
+# Calculating -------------------------------------
+#           Fast Blank   127.247k i/100ms
+#   Fast ActiveSupport   127.443k i/100ms
+#           Slow Blank    78.641k i/100ms
+# -------------------------------------------------
+#           Fast Blank      6.704M (±11.4%) i/s -     33.084M
+#   Fast ActiveSupport      6.811M (±10.9%) i/s -     33.645M
+#           Slow Blank      1.789M (± 8.4%) i/s -      8.965M
+#
+# Comparison:
+#   Fast ActiveSupport:  6811231.1 i/s
+#           Fast Blank:  6704016.0 i/s - 1.02x slower
+#           Slow Blank:  1788751.1 i/s - 3.81x slower
+#
+#
+# ================== Test String Length: 24 ==================
+# Calculating -------------------------------------
+#           Fast Blank   121.925k i/100ms
+#   Fast ActiveSupport   121.461k i/100ms
+#           Slow Blank    73.723k i/100ms
+# -------------------------------------------------
+#           Fast Blank      5.399M (±12.5%) i/s -     26.580M
+#   Fast ActiveSupport      5.584M (±11.7%) i/s -     27.572M
+#           Slow Blank      1.563M (± 8.4%) i/s -      7.815M
+#
+# Comparison:
+#   Fast ActiveSupport:  5584121.3 i/s
+#           Fast Blank:  5398896.6 i/s - 1.03x slower
+#           Slow Blank:  1562511.2 i/s - 3.57x slower
+#
+#
+# ================== Test String Length: 136 ==================
+# Calculating -------------------------------------
+#           Fast Blank   120.336k i/100ms
+#   Fast ActiveSupport   124.404k i/100ms
+#           Slow Blank    75.506k i/100ms
+# -------------------------------------------------
+#           Fast Blank      5.536M (±11.2%) i/s -     27.316M
+#   Fast ActiveSupport      5.622M (±12.0%) i/s -     27.742M
+#           Slow Blank      1.582M (± 7.6%) i/s -      7.928M
+#
+# Comparison:
+#   Fast ActiveSupport:  5622323.3 i/s
+#           Fast Blank:  5535617.1 i/s - 1.02x slower
+#           Slow Blank:  1582003.7 i/s - 3.55x slower
+#

--- a/fast_blank.gemspec
+++ b/fast_blank.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake-compiler'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'benchmark-ips'
 end
 


### PR DESCRIPTION
After https://github.com/SamSaffron/fast_blank/pull/11, I wanted to update the “5-9x faster” line to be more accurate, but didn’t really trust the arbitrary iteration count of the original benchmark, didn’t know how widely the numbers varied, and (mostly) just didn’t want to do the calculations myself manually.

This adds https://github.com/evanphx/benchmark-ips as a development dependency and uses it in the benchmarking script.  In addition to telling me “5-9x” is now “3.5-8x”, it also automatically calculates how many iterations are necessary (now performing 30+ million instead of just 1 million), as well as giving a standard deviation for the benchmarks.