### PR TITLE
Fix "method redefined" Ruby warning in verbose mode

### DIFF
--- a/lib/fast_blank.rb
+++ b/lib/fast_blank.rb
@@ -1,3 +1,8 @@
+class ::String
+  # Explicitly undefine method before redefining to avoid Ruby warnings.
+  undef_method(:blank?) if method_defined?(:blank?)
+end
+
 case RUBY_ENGINE
   when 'jruby'
     require 'fast_blank.jar'

--- a/spec/fast_blank_spec.rb
+++ b/spec/fast_blank_spec.rb
@@ -1,10 +1,17 @@
-require 'fast_blank'
+$VERBOSE = true
 
 class ::String
+  # Stub the original method to make sure it is redefined correctly.
+  def blank?
+    raise NotImplementedError
+  end
+
   def blank2?
     /\A[[:space:]]*\z/ === self
   end
 end
+
+require 'fast_blank'
 
 describe String do
   it "works" do


### PR DESCRIPTION
We usually filter out verbose warnings coming from external gems, but this one slipped through because it is originated from  a C extension, that's how I noticed it.

Anyway, the fix is very simple. I have also enabled the verbose mode in your specs by default so that warnings are easy to spot - the same thing is done in Rails gems.

Before/After:

```
> rake spec
/Users/sema/.rubies/ruby-2.7.1/bin/ruby -I/Users/sema/.gem/ruby/2.7.0/gems/rspec-core-3.10.1/lib:/Users/sema/.gem/ruby/2.7.0/gems/rspec-support-3.10.2/lib /Users/sema/.gem/ruby/2.7.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*/\*_spec.rb
/Users/sema/Code/Clones/fast_blank/lib/fast_blank.bundle: warning: method redefined; discarding old blank?
/Users/sema/Code/Clones/fast_blank/spec/fast_blank_spec.rb:5: warning: previous definition of blank? was here
....

Finished in 0.16338 seconds (files took 0.08029 seconds to load)
4 examples, 0 failures
```

```
> rake spec
/Users/sema/.rubies/ruby-2.7.1/bin/ruby -I/Users/sema/.gem/ruby/2.7.0/gems/rspec-core-3.10.1/lib:/Users/sema/.gem/ruby/2.7.0/gems/rspec-support-3.10.2/lib /Users/sema/.gem/ruby/2.7.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*/\*_spec.rb
....

Finished in 0.16046 seconds (files took 0.07741 seconds to load)
4 examples, 0 failures
```