### PR TITLE
CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'jruby', 'truffleruby' ]
+        ruby: [ '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby', 'truffleruby' ]
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         ruby: [ '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby', 'truffleruby' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,16 @@ on: [ push, pull_request ]
 jobs:
   test:
     name: Test (Ruby ${{ matrix.ruby }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-${{ matrix.ubuntu }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby', 'truffleruby' ]
+        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby', 'truffleruby' ]
+        ubuntu: [ latest ]
+        include:
+          - { ruby: '2.0', ubuntu: '20.04' }
+          - { ruby: '2.1', ubuntu: '20.04' }
+          - { ruby: '2.2', ubuntu: '20.04' }
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Ruby 3.3 has [been released](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)! Let's add it to the CI build matrix for confidence in compatibility.

Additionally:
- Bump actions/checkout from v3 to v4. A little CI hygiene.
- Run Ruby 2.0, 2.1, and 2.2 tests on Ubuntu 20.02 (instead of latest: 22.04). Ruby 2.2 is segfaulting consistently on the newer versions of Ubuntu. Let's pin to the older release to keep the build passing.